### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Math/Quaternion.pm6
+++ b/lib/Math/Quaternion.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class Math::Quaternion does Numeric;
+unit class Math::Quaternion does Numeric;
 
 # One real part (r), and three imaginary parts (i,j,k).
 has Numeric ( $.r, $.i, $.j, $.k );


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.