### PR TITLE
Test appears to be suffering from changed stringification of floats

### DIFF
--- a/t/math_ops.t
+++ b/t/math_ops.t
@@ -16,7 +16,7 @@ my Math::Quaternion $q1 .= new:  2, 3, 4, 5;
 my Math::Quaternion $q2 .= new:  3, 4, 5, 6;
 my Math::Quaternion $qr .= new: $r, 0, 0, 0;
 
-is   $q.norm,   5.47722557505166,   '.norm';
+is   $q.norm,   5.477225575051661,   '.norm';
 
 is_q $q.conj,   [  1, -2, -3, -4 ], '.conj';
 is_q -$q,       [ -1, -2, -3, -4 ], 'Unary minus';


### PR DESCRIPTION
As part of today's Squashathon, this module was [marked as having a problem](https://github.com/perl6/ecosystem-unbitrot/issues/96).  Turns out it was a single test that was testing on the stringification of a float.  Since some work was done in that area recently, I assume that the changed stringification is the source of the problem, not different handling of floating point arithmetic itself.  Hence this change of the test.  Hope that's the right answer!