### PR TITLE
Fix test failure due to Num stringification

### DIFF
--- a/t/math_ops.t
+++ b/t/math_ops.t
@@ -16,7 +16,7 @@ my Math::Quaternion $q1 .= new:  2, 3, 4, 5;
 my Math::Quaternion $q2 .= new:  3, 4, 5, 6;
 my Math::Quaternion $qr .= new: $r, 0, 0, 0;
 
-is   $q.norm,   5.47722557505166,   '.norm';
+is-approx   $q.norm,   5.47722557505166,   '.norm';
 
 is_q $q.conj,   [  1, -2, -3, -4 ], '.conj';
 is_q -$q,       [ -1, -2, -3, -4 ], 'Unary minus';


### PR DESCRIPTION
Currently, you get a test failure like
```
===> Testing: Perl6-Math-Quaternion:auth<Bruce Gray>
[Perl6-Math-Quaternion] # Failed test '.norm'
[Perl6-Math-Quaternion] # at t/math_ops.t line 19
[Perl6-Math-Quaternion] # expected: '5.47722557505166'
[Perl6-Math-Quaternion] #      got: '5.477225575051661'
[Perl6-Math-Quaternion] # Looks like you failed 1 test of 38
===> Testing [FAIL]: Perl6-Math-Quaternion:auth<Bruce Gray>
```

Just change the `is   $q.norm,   5.47722557505166,   '.norm'` to use
`is-aprox` instead.